### PR TITLE
feat: disable keyboard buttons when game is over

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,7 @@ export default function AssemblyEndgame() {
         className={className}
         onClick={() => handleGuess(letter)}
         key={letter}
+        disabled={isGameOver}
       >
         {letter.toUpperCase()}
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@ section.game-status {
 .game-status.lost {
   background-color: #db1515;
 }
-section.game-status.farewell{
+section.game-status.farewell {
   background-color: #7a5ea7;
   border: 1px dashed #323232;
 }
@@ -156,4 +156,9 @@ button.new-game {
 .key.wrong {
   background-color: #f44336;
   color: white;
+}
+
+.key:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
Added \`disabled={isGameOver}\` to prevent further guesses once the game is won or lost.
Improves UX and prevents unintended interactions after game completion."